### PR TITLE
fix(android): remove unused FileInputStream import

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,5 +1,4 @@
 import java.util.Properties
-import java.io.FileInputStream
 
 plugins {
     id("com.android.application")


### PR DESCRIPTION
Fixes #3

Removed the unused `java.io.FileInputStream` import from `android/app/build.gradle.kts`. The code uses Kotlin's `inputStream()` extension function instead, which doesn't require this import.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/egdata-app/egdata-flutter/actions/runs/20639624048) | [Branch: claude/issue-3-20260101-1346](https://github.com/egdata-app/egdata-flutter/tree/claude/issue-3-20260101-1346