### PR TITLE
Refresh Epic sessions automatically before expiry

### DIFF
--- a/desktop/src/main/auth/epic-auth-service.ts
+++ b/desktop/src/main/auth/epic-auth-service.ts
@@ -17,6 +17,10 @@ export const EPIC_LAUNCHER_CLIENT_ID = '34a02cf8f4414e29b15921876da36f9a'
 const EPIC_LAUNCHER_CLIENT_SECRET = 'daafbccc737745039dffe53d94fc76cf'
 const EPIC_LAUNCHER_USER_AGENT =
   'UELauncher/11.0.1-14907503+++Portal+Release-Live Windows/10.0.19045.1.256.64bit'
+const DEFAULT_REFRESH_LEAD_TIME_MS = 5 * 60_000
+const DEFAULT_REFRESH_RETRY_BASE_DELAY_MS = 60_000
+const DEFAULT_REFRESH_RETRY_MAX_DELAY_MS = 15 * 60_000
+const MAX_TIMER_DELAY_MS = 2_147_483_647
 
 export const EPIC_AUTH_PARTITION = 'persist:egdata-epic-auth'
 export const EPIC_AUTH_ORIGINS = Object.freeze([
@@ -43,6 +47,19 @@ export interface EpicAuthServiceOptions {
   requestTimeoutMs?: number
   partition?: string
   now?: () => number
+  refreshLeadTimeMs?: number
+  refreshRetryBaseDelayMs?: number
+  refreshRetryMaxDelayMs?: number
+  onBackgroundRefresh?: (error: Error | null) => void
+}
+
+class TokenExchangeError extends EpicAuthError {
+  readonly retryable: boolean
+
+  constructor(retryable: boolean, options?: ErrorOptions) {
+    super('EPIC_LOGIN_FAILED', options)
+    this.retryable = retryable
+  }
 }
 
 function createEpicAuthWindow(partition: string): AuthWindow {
@@ -127,8 +144,15 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   readonly #requestTimeoutMs: number
   readonly #partition: string
   readonly #now: () => number
+  readonly #refreshLeadTimeMs: number
+  readonly #refreshRetryBaseDelayMs: number
+  readonly #refreshRetryMaxDelayMs: number
+  readonly #onBackgroundRefresh: ((error: Error | null) => void) | undefined
   #tokens: TokenEnvelope | null = null
   #refreshPromise: Promise<void> | null = null
+  #refreshTimer: ReturnType<typeof setTimeout> | null = null
+  #refreshRetryAttempt = 0
+  #disposed = false
 
   constructor(options: EpicAuthServiceOptions) {
     this.#persistence = options.persistence
@@ -149,6 +173,16 @@ export class EpicAuthService implements EpicAuthorizedRequester {
     this.#requestTimeoutMs = options.requestTimeoutMs ?? 20_000
     this.#partition = options.partition ?? EPIC_AUTH_PARTITION
     this.#now = options.now ?? Date.now
+    this.#refreshLeadTimeMs = Math.max(0, options.refreshLeadTimeMs ?? DEFAULT_REFRESH_LEAD_TIME_MS)
+    this.#refreshRetryBaseDelayMs = Math.max(
+      1_000,
+      options.refreshRetryBaseDelayMs ?? DEFAULT_REFRESH_RETRY_BASE_DELAY_MS,
+    )
+    this.#refreshRetryMaxDelayMs = Math.max(
+      this.#refreshRetryBaseDelayMs,
+      options.refreshRetryMaxDelayMs ?? DEFAULT_REFRESH_RETRY_MAX_DELAY_MS,
+    )
+    this.#onBackgroundRefresh = options.onBackgroundRefresh
   }
 
   get isAuthenticated(): boolean {
@@ -173,6 +207,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
         return this.getState()
       }
       this.#tokens = parsed
+      this.#scheduleBackgroundRefresh(parsed.expiresAt)
       return this.getState()
     } catch {
       this.#tokens = null
@@ -191,22 +226,12 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   async refresh(): Promise<void> {
     this.#assertConfigured()
     if (!this.#tokens) throw new EpicAuthError('EPIC_NOT_AUTHENTICATED')
-    if (this.#refreshPromise) return this.#refreshPromise
-
-    const refreshToken = this.#tokens.refreshToken
-    this.#refreshPromise = this.#exchange({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      token_type: 'eg1',
-    })
-      .catch(async (error) => {
-        await this.logout()
-        throw new EpicAuthError('EPIC_SESSION_EXPIRED', { cause: error })
-      })
-      .finally(() => {
-        this.#refreshPromise = null
-      })
-    return this.#refreshPromise
+    try {
+      await this.#refreshTokens()
+    } catch (error) {
+      await this.logout()
+      throw new EpicAuthError('EPIC_SESSION_EXPIRED', { cause: error })
+    }
   }
 
   async authorizedFetch(input: string | URL, init: RequestInit = {}): Promise<Response> {
@@ -220,6 +245,8 @@ export class EpicAuthService implements EpicAuthorizedRequester {
 
   async logout(): Promise<void> {
     this.#tokens = null
+    this.#cancelRefreshTimer()
+    this.#refreshRetryAttempt = 0
     const results = await Promise.allSettled([
       this.#persistence.clear(),
       session.fromPartition(this.#partition).clearStorageData({ storages: ['cookies'] }),
@@ -228,6 +255,11 @@ export class EpicAuthService implements EpicAuthorizedRequester {
       (result): result is PromiseRejectedResult => result.status === 'rejected',
     )
     if (failure) throw failure.reason
+  }
+
+  dispose(): void {
+    this.#disposed = true
+    this.#cancelRefreshTimer()
   }
 
   #assertConfigured(): void {
@@ -253,24 +285,112 @@ export class EpicAuthService implements EpicAuthorizedRequester {
         },
         body: new URLSearchParams(fields),
       })
-      if (!response.ok) throw new EpicAuthError('EPIC_LOGIN_FAILED')
+      if (!response.ok) {
+        const retryable =
+          response.status === 408 || response.status === 429 || response.status >= 500
+        throw new TokenExchangeError(retryable)
+      }
       let decoded: unknown
       try {
         decoded = await response.json()
       } catch (error) {
-        throw new EpicAuthError('EPIC_LOGIN_FAILED', { cause: error })
+        throw new TokenExchangeError(true, { cause: error })
       }
       const tokens = parseTokenResponse(decoded, this.#now())
-      if (!tokens) throw new EpicAuthError('EPIC_LOGIN_FAILED')
+      if (!tokens) throw new TokenExchangeError(false)
 
       const encrypted = this.#cipher.encrypt(JSON.stringify(tokens))
       await this.#persistence.save(encrypted)
       this.#tokens = tokens
+      this.#scheduleBackgroundRefresh(tokens.expiresAt)
     } catch (error) {
       if (error instanceof EpicAuthError) throw error
-      throw new EpicAuthError('EPIC_LOGIN_FAILED', { cause: error })
+      throw new TokenExchangeError(true, { cause: error })
     } finally {
       clearTimeout(timer)
+    }
+  }
+
+  #refreshTokens(): Promise<void> {
+    if (!this.#tokens) return Promise.reject(new EpicAuthError('EPIC_NOT_AUTHENTICATED'))
+    if (this.#refreshPromise) return this.#refreshPromise
+
+    const refreshToken = this.#tokens.refreshToken
+    this.#refreshPromise = this.#exchange({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      token_type: 'eg1',
+    }).finally(() => {
+      this.#refreshPromise = null
+    })
+    return this.#refreshPromise
+  }
+
+  #scheduleBackgroundRefresh(expiresAt: string, resetRetry = true): void {
+    this.#cancelRefreshTimer()
+    if (this.#disposed || !this.#tokens) return
+    if (resetRetry) this.#refreshRetryAttempt = 0
+
+    const delay = Math.max(0, Date.parse(expiresAt) - this.#now() - this.#refreshLeadTimeMs)
+    if (delay > MAX_TIMER_DELAY_MS) {
+      this.#setRefreshTimer(MAX_TIMER_DELAY_MS, () => {
+        this.#scheduleBackgroundRefresh(expiresAt, false)
+      })
+      return
+    }
+    this.#setRefreshTimer(delay, () => void this.#runBackgroundRefresh())
+  }
+
+  #scheduleBackgroundRetry(): void {
+    const exponent = Math.min(this.#refreshRetryAttempt, 30)
+    const delay = Math.min(
+      this.#refreshRetryBaseDelayMs * 2 ** exponent,
+      this.#refreshRetryMaxDelayMs,
+    )
+    this.#refreshRetryAttempt += 1
+    this.#setRefreshTimer(delay, () => void this.#runBackgroundRefresh())
+  }
+
+  #setRefreshTimer(delay: number, callback: () => void): void {
+    this.#refreshTimer = setTimeout(() => {
+      this.#refreshTimer = null
+      callback()
+    }, delay)
+    this.#refreshTimer.unref()
+  }
+
+  #cancelRefreshTimer(): void {
+    if (this.#refreshTimer) clearTimeout(this.#refreshTimer)
+    this.#refreshTimer = null
+  }
+
+  async #runBackgroundRefresh(): Promise<void> {
+    if (this.#disposed || !this.#tokens) return
+    try {
+      await this.#refreshTokens()
+      if (!this.#disposed) this.#notifyBackgroundRefresh(null)
+    } catch (error) {
+      if (this.#disposed || !this.#tokens) return
+      if (error instanceof TokenExchangeError && error.retryable) {
+        this.#scheduleBackgroundRetry()
+      } else {
+        await this.logout().catch(() => undefined)
+      }
+      this.#notifyBackgroundRefresh(
+        error instanceof Error
+          ? error
+          : new EpicAuthError('EPIC_LOGIN_FAILED', {
+              cause: error,
+            }),
+      )
+    }
+  }
+
+  #notifyBackgroundRefresh(error: Error | null): void {
+    try {
+      this.#onBackgroundRefresh?.(error)
+    } catch {
+      // A status observer must not interfere with authentication.
     }
   }
 

--- a/desktop/src/main/auth/epic-auth-service.ts
+++ b/desktop/src/main/auth/epic-auth-service.ts
@@ -62,6 +62,12 @@ class TokenExchangeError extends EpicAuthError {
   }
 }
 
+class SessionInvalidatedError extends EpicAuthError {
+  constructor() {
+    super('EPIC_SESSION_EXPIRED')
+  }
+}
+
 function createEpicAuthWindow(partition: string): AuthWindow {
   return new BrowserWindow({
     width: 520,
@@ -152,6 +158,8 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   #refreshPromise: Promise<void> | null = null
   #refreshTimer: ReturnType<typeof setTimeout> | null = null
   #refreshRetryAttempt = 0
+  #sessionGeneration = 0
+  #tokenMutation: Promise<void> = Promise.resolve()
   #disposed = false
 
   constructor(options: EpicAuthServiceOptions) {
@@ -244,11 +252,12 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   }
 
   async logout(): Promise<void> {
+    this.#sessionGeneration += 1
     this.#tokens = null
     this.#cancelRefreshTimer()
     this.#refreshRetryAttempt = 0
     const results = await Promise.allSettled([
-      this.#persistence.clear(),
+      this.#queueTokenMutation(() => this.#persistence.clear()),
       session.fromPartition(this.#partition).clearStorageData({ storages: ['cookies'] }),
     ])
     const failure = results.find(
@@ -269,6 +278,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   }
 
   async #exchange(fields: Record<string, string>): Promise<void> {
+    const sessionGeneration = this.#sessionGeneration
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), this.#requestTimeoutMs)
     try {
@@ -299,10 +309,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
       const tokens = parseTokenResponse(decoded, this.#now())
       if (!tokens) throw new TokenExchangeError(false)
 
-      const encrypted = this.#cipher.encrypt(JSON.stringify(tokens))
-      await this.#persistence.save(encrypted)
-      this.#tokens = tokens
-      this.#scheduleBackgroundRefresh(tokens.expiresAt)
+      await this.#commitTokens(tokens, sessionGeneration)
     } catch (error) {
       if (error instanceof EpicAuthError) throw error
       throw new TokenExchangeError(true, { cause: error })
@@ -324,6 +331,23 @@ export class EpicAuthService implements EpicAuthorizedRequester {
       this.#refreshPromise = null
     })
     return this.#refreshPromise
+  }
+
+  #commitTokens(tokens: TokenEnvelope, sessionGeneration: number): Promise<void> {
+    return this.#queueTokenMutation(async () => {
+      if (sessionGeneration !== this.#sessionGeneration) throw new SessionInvalidatedError()
+      const encrypted = this.#cipher.encrypt(JSON.stringify(tokens))
+      await this.#persistence.save(encrypted)
+      if (sessionGeneration !== this.#sessionGeneration) throw new SessionInvalidatedError()
+      this.#tokens = tokens
+      this.#scheduleBackgroundRefresh(tokens.expiresAt)
+    })
+  }
+
+  #queueTokenMutation(operation: () => Promise<void>): Promise<void> {
+    const result = this.#tokenMutation.then(operation)
+    this.#tokenMutation = result.catch(() => undefined)
+    return result
   }
 
   #scheduleBackgroundRefresh(expiresAt: string, resetRetry = true): void {

--- a/desktop/src/main/auth/epic-auth-service.ts
+++ b/desktop/src/main/auth/epic-auth-service.ts
@@ -237,6 +237,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
     try {
       await this.#refreshTokens()
     } catch (error) {
+      if (error instanceof TokenExchangeError && error.retryable) throw error
       await this.logout()
       throw new EpicAuthError('EPIC_SESSION_EXPIRED', { cause: error })
     }

--- a/desktop/src/main/auth/epic-auth-service.ts
+++ b/desktop/src/main/auth/epic-auth-service.ts
@@ -408,11 +408,19 @@ export class EpicAuthService implements EpicAuthorizedRequester {
 
   async #runBackgroundRefresh(): Promise<void> {
     if (this.#disposed || !this.#tokens) return
+    const sessionGeneration = this.#sessionGeneration
     try {
       await this.#refreshTokens()
-      if (!this.#disposed) this.#notifyBackgroundRefresh(null)
+      if (!this.#disposed && sessionGeneration === this.#sessionGeneration) {
+        this.#notifyBackgroundRefresh(null)
+      }
     } catch (error) {
-      if (error instanceof SessionInvalidatedError) return
+      if (
+        error instanceof SessionInvalidatedError ||
+        sessionGeneration !== this.#sessionGeneration
+      ) {
+        return
+      }
       if (this.#disposed || !this.#tokens) return
       if (error instanceof TokenExchangeError && error.retryable) {
         this.#scheduleBackgroundRetry()

--- a/desktop/src/main/auth/epic-auth-service.ts
+++ b/desktop/src/main/auth/epic-auth-service.ts
@@ -160,6 +160,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   #refreshRetryAttempt = 0
   #sessionGeneration = 0
   #tokenMutation: Promise<void> = Promise.resolve()
+  #authorizationExchangeActive = false
   #disposed = false
 
   constructor(options: EpicAuthServiceOptions) {
@@ -269,6 +270,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
 
   dispose(): void {
     this.#disposed = true
+    this.#sessionGeneration += 1
     this.#cancelRefreshTimer()
   }
 
@@ -279,6 +281,13 @@ export class EpicAuthService implements EpicAuthorizedRequester {
   }
 
   async #exchange(fields: Record<string, string>): Promise<void> {
+    const isAuthorizationExchange = fields.grant_type === 'authorization_code'
+    if (isAuthorizationExchange) {
+      this.#sessionGeneration += 1
+      this.#cancelRefreshTimer()
+      this.#refreshPromise = null
+      this.#authorizationExchangeActive = true
+    }
     const sessionGeneration = this.#sessionGeneration
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), this.#requestTimeoutMs)
@@ -316,22 +325,30 @@ export class EpicAuthService implements EpicAuthorizedRequester {
       throw new TokenExchangeError(true, { cause: error })
     } finally {
       clearTimeout(timer)
+      if (isAuthorizationExchange && sessionGeneration === this.#sessionGeneration) {
+        this.#authorizationExchangeActive = false
+        if (this.#tokens) this.#scheduleBackgroundRefresh(this.#tokens.expiresAt)
+      }
     }
   }
 
   #refreshTokens(): Promise<void> {
     if (!this.#tokens) return Promise.reject(new EpicAuthError('EPIC_NOT_AUTHENTICATED'))
+    if (this.#authorizationExchangeActive) {
+      return Promise.reject(new TokenExchangeError(true))
+    }
     if (this.#refreshPromise) return this.#refreshPromise
 
     const refreshToken = this.#tokens.refreshToken
-    this.#refreshPromise = this.#exchange({
+    const refreshPromise = this.#exchange({
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
       token_type: 'eg1',
     }).finally(() => {
-      this.#refreshPromise = null
+      if (this.#refreshPromise === refreshPromise) this.#refreshPromise = null
     })
-    return this.#refreshPromise
+    this.#refreshPromise = refreshPromise
+    return refreshPromise
   }
 
   #commitTokens(tokens: TokenEnvelope, sessionGeneration: number): Promise<void> {
@@ -395,6 +412,7 @@ export class EpicAuthService implements EpicAuthorizedRequester {
       await this.#refreshTokens()
       if (!this.#disposed) this.#notifyBackgroundRefresh(null)
     } catch (error) {
+      if (error instanceof SessionInvalidatedError) return
       if (this.#disposed || !this.#tokens) return
       if (error instanceof TokenExchangeError && error.retryable) {
         this.#scheduleBackgroundRetry()

--- a/desktop/src/main/cloud/request.ts
+++ b/desktop/src/main/cloud/request.ts
@@ -1,3 +1,4 @@
+import { EpicAuthError } from '../auth/errors'
 import type { EpicAuthorizedRequester } from '../auth/types'
 import { EpicCloudError, type EpicCloudErrorCode } from './errors'
 
@@ -55,6 +56,12 @@ export async function authorizedFetchWithOneRefresh(
   try {
     await auth.refresh()
   } catch (error) {
+    if (error instanceof EpicAuthError && error.code === 'EPIC_LOGIN_FAILED') {
+      throw new EpicCloudError(options.failureCode, { cause: error })
+    }
+    if (error instanceof EpicAuthError && error.code === 'EPIC_SESSION_EXPIRED') {
+      throw new EpicCloudError('EPIC_SESSION_EXPIRED', { cause: error })
+    }
     await auth.logout().catch(() => undefined)
     throw new EpicCloudError('EPIC_SESSION_EXPIRED', { cause: error })
   }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -162,6 +162,15 @@ class DesktopIpcServices {
     this.#auth = new EpicAuthService({
       persistence: tokenStorage,
       cipher: new SafeStorageTokenCipher(safeStorage),
+      onBackgroundRefresh: (error) => {
+        const status = this.#authStatus()
+        this.#send(IPC_CHANNELS.auth.statusEvent, status)
+        if (error) {
+          void this.#logger.warn('auth', 'Background Epic session renewal failed', { error })
+        } else {
+          void this.#logger.debug('auth', 'Epic session renewed in the background')
+        }
+      },
     })
     this.#library = new EpicLibraryService({ auth: this.#auth, platform: this.#platform })
     this.#libraryTools = new LibraryToolsService({
@@ -637,6 +646,7 @@ class DesktopIpcServices {
       powerMonitor.removeListener('resume', this.#powerResumeListener)
       this.#scheduledUploads?.dispose()
       this.#scheduledUploads = null
+      this.#auth.dispose()
       this.#catalog.stop()
       this.#catalog.close()
       this.#disposeQueue?.()

--- a/desktop/test/contract/cloud-auth.test.ts
+++ b/desktop/test/contract/cloud-auth.test.ts
@@ -445,4 +445,57 @@ describe('EpicAuthService contract', () => {
       vi.useRealTimers()
     }
   })
+
+  it('keeps the session when a foreground refresh joins a transient background failure', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-01T00:00:00.000Z')
+    const persistence = new MemoryPersistence()
+    persistence.value = cipher.encrypt(
+      JSON.stringify({
+        version: 1,
+        accessToken: 'private-access-1',
+        refreshToken: 'private-refresh-1',
+        accountId: 'account-id',
+        expiresAt: '2026-01-01T00:05:00.000Z',
+      }),
+    )
+    let resolveTokenRequest!: (response: Response) => void
+    const tokenRequest = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveTokenRequest = resolve
+        }),
+    )
+    const onBackgroundRefresh = vi.fn()
+    const service = new EpicAuthService({
+      persistence,
+      cipher,
+      clientId: 'environment-client-id',
+      clientSecret: 'environment-client-secret',
+      fetch: tokenRequest,
+      onBackgroundRefresh,
+    })
+
+    try {
+      await service.initialize()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(tokenRequest).toHaveBeenCalledOnce()
+
+      const foregroundRefresh = service.refresh()
+      resolveTokenRequest(new Response(null, { status: 503 }))
+
+      await expect(foregroundRefresh).rejects.toMatchObject({ code: 'EPIC_LOGIN_FAILED' })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(service.isAuthenticated).toBe(true)
+      expect(persistence.value).not.toBeNull()
+      expect(onBackgroundRefresh.mock.calls[0]?.[0]).toMatchObject({
+        code: 'EPIC_LOGIN_FAILED',
+      })
+      expect(vi.getTimerCount()).toBe(1)
+    } finally {
+      service.dispose()
+      vi.useRealTimers()
+    }
+  })
 })

--- a/desktop/test/contract/cloud-auth.test.ts
+++ b/desktop/test/contract/cloud-auth.test.ts
@@ -265,5 +265,125 @@ describe('EpicAuthService contract', () => {
     })
     expect(persistence.value).not.toContain('private-access-2')
     expect(persistence.value).not.toContain('private-refresh-2')
+    service.dispose()
+  })
+
+  it('renews a restored session once in the background shortly before expiry', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-01T00:00:00.000Z')
+    const persistence = new MemoryPersistence()
+    persistence.value = cipher.encrypt(
+      JSON.stringify({
+        version: 1,
+        accessToken: 'private-access-1',
+        refreshToken: 'private-refresh-1',
+        accountId: 'account-id',
+        expiresAt: '2026-01-01T01:00:00.000Z',
+      }),
+    )
+    const tokenRequest = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: 'private-access-2',
+            refresh_token: 'private-refresh-2',
+            account_id: 'account-id',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const onBackgroundRefresh = vi.fn()
+    const service = new EpicAuthService({
+      persistence,
+      cipher,
+      clientId: 'environment-client-id',
+      clientSecret: 'environment-client-secret',
+      fetch: tokenRequest,
+      onBackgroundRefresh,
+    })
+
+    try {
+      await service.initialize()
+      await vi.advanceTimersByTimeAsync(54 * 60_000 + 59_999)
+      expect(tokenRequest).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+
+      expect(tokenRequest).toHaveBeenCalledOnce()
+      const requestBody = tokenRequest.mock.calls[0]?.[1]?.body
+      expect(requestBody).toBeInstanceOf(URLSearchParams)
+      expect((requestBody as URLSearchParams).get('grant_type')).toBe('refresh_token')
+      expect((requestBody as URLSearchParams).get('refresh_token')).toBe('private-refresh-1')
+      expect(onBackgroundRefresh).toHaveBeenCalledWith(null)
+      expect(service.getState()).toEqual({
+        authenticated: true,
+        accountId: 'account-id',
+        expiresAt: '2026-01-01T01:55:00.000Z',
+      })
+    } finally {
+      service.dispose()
+      vi.useRealTimers()
+    }
+  })
+
+  it('backs off after a temporary background renewal failure without losing the session', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-01T00:00:00.000Z')
+    const persistence = new MemoryPersistence()
+    persistence.value = cipher.encrypt(
+      JSON.stringify({
+        version: 1,
+        accessToken: 'private-access-1',
+        refreshToken: 'private-refresh-1',
+        accountId: 'account-id',
+        expiresAt: '2026-01-01T00:05:00.000Z',
+      }),
+    )
+    const tokenRequest = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            access_token: 'private-access-2',
+            refresh_token: 'private-refresh-2',
+            account_id: 'account-id',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    const onBackgroundRefresh = vi.fn()
+    const service = new EpicAuthService({
+      persistence,
+      cipher,
+      clientId: 'environment-client-id',
+      clientSecret: 'environment-client-secret',
+      fetch: tokenRequest,
+      onBackgroundRefresh,
+    })
+
+    try {
+      await service.initialize()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(tokenRequest).toHaveBeenCalledOnce()
+      expect(service.isAuthenticated).toBe(true)
+      expect(onBackgroundRefresh).toHaveBeenCalledTimes(1)
+      expect(onBackgroundRefresh.mock.calls[0]?.[0]).toBeInstanceOf(Error)
+
+      await vi.advanceTimersByTimeAsync(59_999)
+      expect(tokenRequest).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(1)
+
+      expect(tokenRequest).toHaveBeenCalledTimes(2)
+      expect(service.isAuthenticated).toBe(true)
+      expect(onBackgroundRefresh).toHaveBeenLastCalledWith(null)
+    } finally {
+      service.dispose()
+      vi.useRealTimers()
+    }
   })
 })

--- a/desktop/test/contract/cloud-auth.test.ts
+++ b/desktop/test/contract/cloud-auth.test.ts
@@ -499,93 +499,95 @@ describe('EpicAuthService contract', () => {
     }
   })
 
-  it('does not let an older background renewal overwrite a new login', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime('2026-01-01T00:00:00.000Z')
-    const persistence = new MemoryPersistence()
-    persistence.value = cipher.encrypt(
-      JSON.stringify({
-        version: 1,
-        accessToken: 'old-private-access',
-        refreshToken: 'old-private-refresh',
-        accountId: 'old-account-id',
-        expiresAt: '2026-01-01T00:05:00.000Z',
-      }),
-    )
-    let resolveRefreshRequest!: (response: Response) => void
-    const tokenRequest = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
-      const body = init?.body
-      const grantType =
-        body instanceof URLSearchParams ? body.get('grant_type') : 'authorization_code'
-      if (grantType === 'refresh_token') {
-        return new Promise<Response>((resolve) => {
-          resolveRefreshRequest = resolve
+  it.each([200, 400, 503])(
+    'ignores an older background renewal response after a new login (status %i)',
+    async (staleStatus) => {
+      vi.useFakeTimers()
+      vi.setSystemTime('2026-01-01T00:00:00.000Z')
+      const persistence = new MemoryPersistence()
+      persistence.value = cipher.encrypt(
+        JSON.stringify({
+          version: 1,
+          accessToken: 'old-private-access',
+          refreshToken: 'old-private-refresh',
+          accountId: 'old-account-id',
+          expiresAt: '2026-01-01T00:05:00.000Z',
+        }),
+      )
+      let resolveRefreshRequest!: (response: Response) => void
+      const tokenRequest = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+        const body = init?.body
+        const grantType =
+          body instanceof URLSearchParams ? body.get('grant_type') : 'authorization_code'
+        if (grantType === 'refresh_token') {
+          return new Promise<Response>((resolve) => {
+            resolveRefreshRequest = resolve
+          })
+        }
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: 'new-private-access',
+              refresh_token: 'new-private-refresh',
+              account_id: 'new-account-id',
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          ),
+        )
+      })
+      const onBackgroundRefresh = vi.fn()
+      const service = new EpicAuthService({
+        persistence,
+        cipher,
+        clientId: 'environment-client-id',
+        clientSecret: 'environment-client-secret',
+        createWindow: () => new FakeWindow(),
+        fetch: tokenRequest,
+        onBackgroundRefresh,
+      })
+
+      try {
+        await service.initialize()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(tokenRequest).toHaveBeenCalledOnce()
+
+        await service.login()
+        expect(service.getState()).toMatchObject({
+          authenticated: true,
+          accountId: 'new-account-id',
         })
+
+        const staleBody =
+          staleStatus === 200
+            ? JSON.stringify({
+                access_token: 'stale-private-access',
+                refresh_token: 'stale-private-refresh',
+                account_id: 'old-account-id',
+                expires_in: 3600,
+              })
+            : null
+        resolveRefreshRequest(new Response(staleBody, { status: staleStatus }))
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(service.getState()).toMatchObject({
+          authenticated: true,
+          accountId: 'new-account-id',
+        })
+        const persisted = JSON.parse(cipher.decrypt(persistence.value!)) as {
+          accountId: string
+          accessToken: string
+        }
+        expect(persisted).toMatchObject({
+          accountId: 'new-account-id',
+          accessToken: 'new-private-access',
+        })
+        expect(onBackgroundRefresh).not.toHaveBeenCalled()
+        expect(vi.getTimerCount()).toBe(1)
+      } finally {
+        service.dispose()
+        vi.useRealTimers()
       }
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            access_token: 'new-private-access',
-            refresh_token: 'new-private-refresh',
-            account_id: 'new-account-id',
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        ),
-      )
-    })
-    const onBackgroundRefresh = vi.fn()
-    const service = new EpicAuthService({
-      persistence,
-      cipher,
-      clientId: 'environment-client-id',
-      clientSecret: 'environment-client-secret',
-      createWindow: () => new FakeWindow(),
-      fetch: tokenRequest,
-      onBackgroundRefresh,
-    })
-
-    try {
-      await service.initialize()
-      await vi.advanceTimersByTimeAsync(0)
-      expect(tokenRequest).toHaveBeenCalledOnce()
-
-      await service.login()
-      expect(service.getState()).toMatchObject({
-        authenticated: true,
-        accountId: 'new-account-id',
-      })
-
-      resolveRefreshRequest(
-        new Response(
-          JSON.stringify({
-            access_token: 'stale-private-access',
-            refresh_token: 'stale-private-refresh',
-            account_id: 'old-account-id',
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        ),
-      )
-      await vi.advanceTimersByTimeAsync(0)
-
-      expect(service.getState()).toMatchObject({
-        authenticated: true,
-        accountId: 'new-account-id',
-      })
-      const persisted = JSON.parse(cipher.decrypt(persistence.value!)) as {
-        accountId: string
-        accessToken: string
-      }
-      expect(persisted).toMatchObject({
-        accountId: 'new-account-id',
-        accessToken: 'new-private-access',
-      })
-      expect(onBackgroundRefresh).not.toHaveBeenCalled()
-      expect(vi.getTimerCount()).toBe(1)
-    } finally {
-      service.dispose()
-      vi.useRealTimers()
-    }
-  })
+    },
+  )
 })

--- a/desktop/test/contract/cloud-auth.test.ts
+++ b/desktop/test/contract/cloud-auth.test.ts
@@ -498,4 +498,94 @@ describe('EpicAuthService contract', () => {
       vi.useRealTimers()
     }
   })
+
+  it('does not let an older background renewal overwrite a new login', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-01T00:00:00.000Z')
+    const persistence = new MemoryPersistence()
+    persistence.value = cipher.encrypt(
+      JSON.stringify({
+        version: 1,
+        accessToken: 'old-private-access',
+        refreshToken: 'old-private-refresh',
+        accountId: 'old-account-id',
+        expiresAt: '2026-01-01T00:05:00.000Z',
+      }),
+    )
+    let resolveRefreshRequest!: (response: Response) => void
+    const tokenRequest = vi.fn((_input: string | URL | Request, init?: RequestInit) => {
+      const body = init?.body
+      const grantType =
+        body instanceof URLSearchParams ? body.get('grant_type') : 'authorization_code'
+      if (grantType === 'refresh_token') {
+        return new Promise<Response>((resolve) => {
+          resolveRefreshRequest = resolve
+        })
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: 'new-private-access',
+            refresh_token: 'new-private-refresh',
+            account_id: 'new-account-id',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    })
+    const onBackgroundRefresh = vi.fn()
+    const service = new EpicAuthService({
+      persistence,
+      cipher,
+      clientId: 'environment-client-id',
+      clientSecret: 'environment-client-secret',
+      createWindow: () => new FakeWindow(),
+      fetch: tokenRequest,
+      onBackgroundRefresh,
+    })
+
+    try {
+      await service.initialize()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(tokenRequest).toHaveBeenCalledOnce()
+
+      await service.login()
+      expect(service.getState()).toMatchObject({
+        authenticated: true,
+        accountId: 'new-account-id',
+      })
+
+      resolveRefreshRequest(
+        new Response(
+          JSON.stringify({
+            access_token: 'stale-private-access',
+            refresh_token: 'stale-private-refresh',
+            account_id: 'old-account-id',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(service.getState()).toMatchObject({
+        authenticated: true,
+        accountId: 'new-account-id',
+      })
+      const persisted = JSON.parse(cipher.decrypt(persistence.value!)) as {
+        accountId: string
+        accessToken: string
+      }
+      expect(persisted).toMatchObject({
+        accountId: 'new-account-id',
+        accessToken: 'new-private-access',
+      })
+      expect(onBackgroundRefresh).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(1)
+    } finally {
+      service.dispose()
+      vi.useRealTimers()
+    }
+  })
 })

--- a/desktop/test/contract/cloud-auth.test.ts
+++ b/desktop/test/contract/cloud-auth.test.ts
@@ -386,4 +386,63 @@ describe('EpicAuthService contract', () => {
       vi.useRealTimers()
     }
   })
+
+  it('does not restore a session when logout wins a race with background renewal', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime('2026-01-01T00:00:00.000Z')
+    const persistence = new MemoryPersistence()
+    persistence.value = cipher.encrypt(
+      JSON.stringify({
+        version: 1,
+        accessToken: 'private-access-1',
+        refreshToken: 'private-refresh-1',
+        accountId: 'account-id',
+        expiresAt: '2026-01-01T00:05:00.000Z',
+      }),
+    )
+    let resolveTokenRequest!: (response: Response) => void
+    const tokenRequest = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveTokenRequest = resolve
+        }),
+    )
+    const onBackgroundRefresh = vi.fn()
+    const service = new EpicAuthService({
+      persistence,
+      cipher,
+      clientId: 'environment-client-id',
+      clientSecret: 'environment-client-secret',
+      fetch: tokenRequest,
+      onBackgroundRefresh,
+    })
+
+    try {
+      await service.initialize()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(tokenRequest).toHaveBeenCalledOnce()
+
+      await service.logout()
+      resolveTokenRequest(
+        new Response(
+          JSON.stringify({
+            access_token: 'stale-private-access',
+            refresh_token: 'stale-private-refresh',
+            account_id: 'account-id',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(service.isAuthenticated).toBe(false)
+      expect(persistence.value).toBeNull()
+      expect(onBackgroundRefresh).not.toHaveBeenCalled()
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      service.dispose()
+      vi.useRealTimers()
+    }
+  })
 })

--- a/desktop/test/integration/cloud-library.test.ts
+++ b/desktop/test/integration/cloud-library.test.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises'
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { EpicAuthError } from '../../src/main/auth/errors'
 import type { EpicAuthorizedRequester } from '../../src/main/auth/types'
 import { EpicLibraryService } from '../../src/main/cloud'
 
@@ -69,6 +70,25 @@ describe('EpicLibraryService', () => {
     expect(refresh).toHaveBeenCalledTimes(1)
     expect(authorizedFetch).toHaveBeenCalledTimes(2)
     expect(logout).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves the session when token renewal fails temporarily', async () => {
+    const authorizedFetch = vi.fn(() => Promise.resolve(new Response(null, { status: 401 })))
+    const refresh = vi.fn(() => Promise.reject(new EpicAuthError('EPIC_LOGIN_FAILED')))
+    const logout = vi.fn(() => Promise.resolve())
+    const auth: EpicAuthorizedRequester = {
+      isAuthenticated: true,
+      authorizedFetch,
+      refresh,
+      logout,
+    }
+
+    await expect(
+      new EpicLibraryService({ auth, platform: 'Windows' }).getLibrary(),
+    ).rejects.toMatchObject({ code: 'EPIC_LIBRARY_REQUEST_FAILED' })
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(authorizedFetch).toHaveBeenCalledTimes(1)
+    expect(logout).not.toHaveBeenCalled()
   })
 
   it('bounds reading of a stalled response body', async () => {


### PR DESCRIPTION
## Summary
- Add background Epic token renewal five minutes before expiry
- Retry transient renewal failures with exponential backoff while preserving the session
- Notify the renderer of renewal status and dispose refresh timers during shutdown

## Testing
- Added contract tests covering scheduled renewal and retry backoff behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now renew automatically in the background before expiration.
  * Temporary renewal failures retry automatically with increasing delays, helping preserve active sessions.
  * Authentication status updates are emitted when background renewal succeeds or fails.
  * Added configurable timing and retry settings for background session renewal.

* **Bug Fixes**
  * Authentication timers are now properly stopped when signing out or shutting down, preventing stale background activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->